### PR TITLE
added rule for linebreak style issue between mac and windows;

### DIFF
--- a/Frontend/.eslintrc.json
+++ b/Frontend/.eslintrc.json
@@ -49,6 +49,7 @@
                 "ImportDeclaration": "first"
             }
         ],
+        "linebreak-style": 0,
         "quotes": ["warn", "single"],
         "object-curly-spacing": "warn",
         "jsx-quotes": "warn",


### PR DESCRIPTION
# Pull request

## Description

[//]: # (Summary of changes. List any dependency changes required for this change)

turn off eslint rule for line break, could be issues between mac and windows

## Type of Change

- [x] Refactor (non-breaking change which improves code performance or readability)
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change that adds functionality)
- [ ] Documentation (changes to docs and not code)
- [ ] Breaking Change (Fix or change that would cause existing functionality to not work as expected)
- [ ] Test


## How it was tested

Enter description of testing

- [ ] Unit Test
- [ ] Manual / Postman(if backend)
- [ ] Integration

## Affirmations

- [ ] I follow coding guidelines (TBD)
- [ ] I have self-reviewed my code
- [ ] I have run eslint and fixes issues (Mostly works but needs more rules and a fix)
- [ ] I have commented code when necessary or difficult
- [ ] I have made changes to docs where required
- [ ] My changes generate no new warnings
- [ ] I have added tests
- [ ] New and existing tests pass